### PR TITLE
Fix change log report

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -246,32 +246,28 @@ jobs:
 
           # Create temporary file for changelog
           if [ -z "$LATEST_TAG" ]; then
-            git log -${COMMIT_COUNT} --pretty=format:"- %s [%h]" > /tmp/changelog.txt
+            git log -${COMMIT_COUNT} --pretty=format:"- %s [%h]" > changelog.tmp
           else
             COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
-              echo "No changes since last nightly build." > /tmp/changelog.txt
+              echo "No changes since last nightly build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --pretty=format:"- %s [%h]" > /tmp/changelog.txt
+              git log ${LATEST_TAG}..HEAD --pretty=format:"- %s [%h]" > changelog.tmp
             fi
           fi
 
-          # Use GitHub's heredoc syntax to safely set multiline variables
-          {
-            echo 'CHANGELOG<<EOF'
-            cat /tmp/changelog.txt
-            echo 'EOF'
-          } >> $GITHUB_ENV
+          # Set environment variable using heredoc
+          echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
+          cat changelog.tmp >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
 
-          # Also set as step output using the same method
-          {
-            echo 'changelog<<EOF'
-            cat /tmp/changelog.txt
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+          # Set output variable using heredoc
+          echo 'changelog<<EOF' >> $GITHUB_OUTPUT
+          cat changelog.tmp >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
-          # Clean up
-          rm -f /tmp/changelog.txt
+          # Clean up temporary file
+          rm changelog.tmp
 
       - name: Create GitHub Release
         id: create_release

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -256,15 +256,13 @@ jobs:
             fi
           fi
 
-          # Set environment variable using heredoc
-          echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
-          cat changelog.tmp >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          CHANGELOG_CONTENT="$(cat changelog.tmp)"
 
-          # Set output variable using heredoc
-          echo 'changelog<<EOF' >> $GITHUB_OUTPUT
-          cat changelog.tmp >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          # Set environment variable
+          printf "CHANGELOG<<EOF\n%s\nEOF\n" "$CHANGELOG_CONTENT" >> $GITHUB_ENV
+
+          # Set output variable
+          printf "changelog<<EOF\n%s\nEOF\n" "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
 
           # Clean up temporary file
           rm changelog.tmp


### PR DESCRIPTION
## 📝 Descrição

🔗 **Issue relacionada:** sem issue

Este PR corrige o problema no workflow de Nightly Build relacionado à geração do changelog.
Anteriormente, o uso de echo >> $GITHUB_ENV e echo >> $GITHUB_OUTPUT resultava no erro:

> Error: Invalid value. Matching delimiter not found 'EOF'


A solução foi substituir pelo uso de printf, que garante a escrita correta de variáveis multilinha (como o changelog) nos arquivos especiais do GitHub Actions.


## ✅ Checklist

- [x] Revisei a doc [Pull Request](https://github.com/PointTils/Frontend/wiki/Pull-Requests) e abri meu PR de acordo
- [x] Meu código segue os padrões de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código, especialmente em áreas difíceis de entender
- [x] Minhas mudanças não geram novos warnings
- [x] Testei em dispositivo físico/emulador

## 📋 Informações Adicionais

Adicione qualquer contexto adicional sobre o PR aqui.

---

> **Nota:** Certifique-se de que todos os checks da CI passaram antes de solicitar review.
