### PR TITLE
ci: compare changelog against previous tag instead of latest

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -233,12 +233,14 @@ jobs:
           git fetch --tags --force
 
           if [ "$PROFILE" = "production" ]; then
-            # For production builds, compare with the latest production tag (v*.*.*)
-            LATEST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | grep -v "nightly" | sed -n 2p)
+            # For production builds, compare with the latest production tag
+            CURRENT_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0)
+            LATEST_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
             echo "📦 Production build - comparing with latest production tag: ${LATEST_TAG:-none}"
           else
             # For preview builds, compare with the latest nightly tag
-            LATEST_TAG=$(git tag -l "v*-nightly.*" --sort=-creatordate | sed -n 2p)
+            CURRENT_TAG=$(git describe --tags --match "v*-nightly.*" --abbrev=0)
+            LATEST_TAG=$(git describe --tags --match "v*-nightly.*" --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
             echo "🌙 Preview build - comparing with latest nightly tag: ${LATEST_TAG:-none}"
           fi
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -234,11 +234,11 @@ jobs:
 
           if [ "$PROFILE" = "production" ]; then
             # For production builds, compare with the latest production tag (v*.*.*)
-            LATEST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | grep -v "nightly" | head -n 1)
+            LATEST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | grep -v "nightly" | sed -n 2p)
             echo "📦 Production build - comparing with latest production tag: ${LATEST_TAG:-none}"
           else
             # For preview builds, compare with the latest nightly tag
-            LATEST_TAG=$(git tag -l "v*-nightly.*" --sort=-creatordate | head -n 1)
+            LATEST_TAG=$(git tag -l "v*-nightly.*" --sort=-creatordate | sed -n 2p)
             echo "🌙 Preview build - comparing with latest nightly tag: ${LATEST_TAG:-none}"
           fi
 
@@ -246,13 +246,13 @@ jobs:
 
           # Create temporary file for changelog
           if [ -z "$LATEST_TAG" ]; then
-            git log -${COMMIT_COUNT} --pretty=format:"- %s [%h]" > changelog.tmp
+            echo "" > changelog.tmp
           else
             COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
               echo "No changes since last nightly build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --pretty=format:"- %s [%h]" > changelog.tmp
+              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
             fi
           fi
 
@@ -274,12 +274,11 @@ jobs:
           tag_name: v${{ needs.build.outputs.nightly_version }}
           release_name: Point Tils ${{ needs.build.outputs.nightly_version }} [${{ github.event.inputs.profile || 'preview' }}]
           body: |
-            ${{ (github.event.inputs.profile || 'preview') == 'production' && '🚀 Production Build' || '🌙 Nightly Build' }} Report
             - **Date:** ${{ env.CURRENT_DATE }}
             - **Base Version:** ${{ needs.build.outputs.original_version }}
             - **Build ID:** ${{ needs.build.outputs.build_id || 'Not available' }}
-            ---
-            ### What's new
+
+            ## What's new
             ${{ env.CHANGELOG }}
           draft: false
           prerelease: ${{ (github.event.inputs.profile || 'preview') == 'preview' }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -233,28 +233,35 @@ jobs:
           git fetch --tags --force
 
           if [ "$PROFILE" = "production" ]; then
-            # For production builds, compare with the latest production tag
-            CURRENT_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0)
-            LATEST_TAG=$(git describe --tags --match "v*.*.*" --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
-            echo "📦 Production build - comparing with latest production tag: ${LATEST_TAG:-none}"
+            # For production builds, get the two most recent production tags
+            LATEST_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+            PREVIOUS_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 2 | tail -n 1)
+            echo "📦 Production build - comparing ${PREVIOUS_TAG:-none} with ${LATEST_TAG:-none}"
           else
-            # For preview builds, compare with the latest nightly tag
-            CURRENT_TAG=$(git describe --tags --match "v*-nightly.*" --abbrev=0)
-            LATEST_TAG=$(git describe --tags --match "v*-nightly.*" --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
-            echo "🌙 Preview build - comparing with latest nightly tag: ${LATEST_TAG:-none}"
+            # For preview builds, get the two most recent nightly tags
+            LATEST_TAG=$(git tag -l "v*-nightly.*" --sort=-version:refname | head -n 1)
+            PREVIOUS_TAG=$(git tag -l "v*-nightly.*" --sort=-version:refname | head -n 2 | tail -n 1)
+            echo "🌙 Preview build - comparing ${PREVIOUS_TAG:-none} with ${LATEST_TAG:-none}"
+          fi
+
+
+          # Use PREVIOUS_TAG for comparison if it exists, otherwise compare from the beginning
+          COMPARE_TAG=""
+          if [ -n "$PREVIOUS_TAG" ] && [ "$PREVIOUS_TAG" != "$LATEST_TAG" ]; then
+            COMPARE_TAG="$PREVIOUS_TAG"
           fi
 
           COMMIT_COUNT=10
-
           # Create temporary file for changelog
-          if [ -z "$LATEST_TAG" ]; then
+          if [ -z "$COMPARE_TAG" ]; then
+            # If no previous tag, print nothing
             echo "" > changelog.tmp
           else
-            COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
+            COMMITS_SINCE=$(git rev-list --count ${COMPARE_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
               echo "No changes since last nightly build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
+              git log ${COMPARE_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
             fi
           fi
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -251,7 +251,7 @@ jobs:
             if [ "$COMMITS_SINCE" -eq 0 ]; then
               echo "No changes since last build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
+              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" | grep "Merge pull request" > changelog.tmp
             fi
           fi
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -250,13 +250,13 @@ jobs:
           # Create temporary file for changelog
           if [ -z "$LATEST_TAG" ]; then
             # If no previous tag, print the last 5 merge commits
-            git log -n 5 --merges --pretty=format:"- %s - %an" | grep "Merge pull request" > changelog.tmp
+            git log -n 5 --merges --pretty=format:"- %s - @%an" | grep "Merge pull request" > changelog.tmp
           else
             COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
               echo "No changes since last build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s - %an" | grep "Merge pull request" > changelog.tmp
+              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s - @%an" | grep "Merge pull request" > changelog.tmp
             fi
           fi
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -63,15 +63,17 @@ jobs:
         run: npm install -g eas-cli@latest
 
       - name: Verify EAS Authentication
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           if ! eas whoami; then
             exit 1
           fi
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
       - name: Generate build
         id: build-step
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           echo "Generating build..."
           ORIGINAL_VERSION=$(node -p "require('./package.json').version")
@@ -119,11 +121,11 @@ jobs:
           BUILD_ID=$(echo "$BUILD_JSON" | jq -r '.[0].id')
           echo "build_id=${BUILD_ID}" >> $GITHUB_OUTPUT
           echo "BUILD_ID=${BUILD_ID}" >> $GITHUB_ENV
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
       - name: Wait for build completion
         id: build-status
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           echo "⏳ Waiting for build to complete..."
 
@@ -199,8 +201,6 @@ jobs:
           echo "build_url=${FINAL_URL}" >> $GITHUB_OUTPUT
           echo "BUILD_STATUS=${BUILD_STATUS}" >> $GITHUB_ENV
           echo "BUILD_URL=${FINAL_URL}" >> $GITHUB_ENV
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
       - name: Restore app.json
         if: always()
@@ -274,9 +274,14 @@ jobs:
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
         with:
           tag_name: v${{ needs.build.outputs.nightly_version }}
+          commitish: ${{ github.event.inputs.branch || 'dev' }}
           release_name: Point Tils ${{ needs.build.outputs.nightly_version }} [${{ github.event.inputs.profile || 'preview' }}]
+          draft: false
+          prerelease: ${{ (github.event.inputs.profile || 'preview') == 'preview' }}
           body: |
             - **Date:** ${{ env.CURRENT_DATE }}
             - **Base Version:** ${{ needs.build.outputs.original_version }}
@@ -284,10 +289,6 @@ jobs:
 
             ## What's new
             ${{ env.CHANGELOG }}
-          draft: false
-          prerelease: ${{ (github.event.inputs.profile || 'preview') == 'preview' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Download APK from EAS
         if: ${{ needs.build.outputs.build_status == 'FINISHED' && needs.build.outputs.build_url != 'Not available' }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -234,6 +234,9 @@ jobs:
           PROFILE="${{ github.event.inputs.profile || 'preview' }}"
           git fetch --tags --force
 
+          CURRENT_BRANCH=$(git branch --show-current)
+          echo "Current branch: $CURRENT_BRANCH"
+
           if [ "$PROFILE" = "production" ]; then
             # For production builds, get the two most recent production tags
             LATEST_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -235,33 +235,23 @@ jobs:
           if [ "$PROFILE" = "production" ]; then
             # For production builds, get the two most recent production tags
             LATEST_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-            PREVIOUS_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 2 | tail -n 1)
-            echo "📦 Production build - comparing ${PREVIOUS_TAG:-none} with ${LATEST_TAG:-none}"
+            echo "📦 Production build - comparing ${LATEST_TAG:-none} with HEAD"
           else
             # For preview builds, get the two most recent nightly tags
             LATEST_TAG=$(git tag -l "v*-nightly.*" --sort=-version:refname | head -n 1)
-            PREVIOUS_TAG=$(git tag -l "v*-nightly.*" --sort=-version:refname | head -n 2 | tail -n 1)
-            echo "🌙 Preview build - comparing ${PREVIOUS_TAG:-none} with ${LATEST_TAG:-none}"
+            echo "🌙 Preview build - comparing ${LATEST_TAG:-none} with HEAD"
           fi
 
-
-          # Use PREVIOUS_TAG for comparison if it exists, otherwise compare from the beginning
-          COMPARE_TAG=""
-          if [ -n "$PREVIOUS_TAG" ] && [ "$PREVIOUS_TAG" != "$LATEST_TAG" ]; then
-            COMPARE_TAG="$PREVIOUS_TAG"
-          fi
-
-          COMMIT_COUNT=10
           # Create temporary file for changelog
-          if [ -z "$COMPARE_TAG" ]; then
+          if [ -z "$LATEST_TAG" ]; then
             # If no previous tag, print nothing
             echo "" > changelog.tmp
           else
-            COMMITS_SINCE=$(git rev-list --count ${COMPARE_TAG}..HEAD)
+            COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
-              echo "No changes since last nightly build." > changelog.tmp
+              echo "No changes since last build." > changelog.tmp
             else
-              git log ${COMPARE_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
+              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" > changelog.tmp
             fi
           fi
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'dev' }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -222,6 +223,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'dev' }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Capture current date and time
         run: echo "CURRENT_DATE=$(TZ=America/Sao_Paulo date '+%d/%m/%Y %H:%M:%S')" >> $GITHUB_ENV
@@ -244,14 +246,14 @@ jobs:
 
           # Create temporary file for changelog
           if [ -z "$LATEST_TAG" ]; then
-            # If no previous tag, print nothing
-            echo "" > changelog.tmp
+            # If no previous tag, print the last 5 merge commits
+            git log -n 5 --merges --pretty=format:"- %s - %an" | grep "Merge pull request" > changelog.tmp
           else
             COMMITS_SINCE=$(git rev-list --count ${LATEST_TAG}..HEAD)
             if [ "$COMMITS_SINCE" -eq 0 ]; then
               echo "No changes since last build." > changelog.tmp
             else
-              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s [%h]" | grep "Merge pull request" > changelog.tmp
+              git log ${LATEST_TAG}..HEAD --merges --pretty=format:"- %s - %an" | grep "Merge pull request" > changelog.tmp
             fi
           fi
 


### PR DESCRIPTION
## 📝 Descrição

🔗 **Issue relacionada:** sem issue

- Comparação agora usa a penúltima tag, evitando repetir changelog.
- Changelog mostra só merges de PRs.
- Primeira release gera changelog vazio (não lista commits antigos).

## ✅ Checklist

- [x] Revisei a doc [Pull Request](https://github.com/PointTils/Frontend/wiki/Pull-Requests) e abri meu PR de acordo
- [x] Meu código segue os padrões de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código, especialmente em áreas difíceis de entender
- [x] Minhas mudanças não geram novos warnings
- [x] Testei em dispositivo físico/emulador

## 📋 Informações Adicionais

Adicione qualquer contexto adicional sobre o PR aqui.

---

> **Nota:** Certifique-se de que todos os checks da CI passaram antes de solicitar review.
