### PR TITLE
Correção de deps para geração do APK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/html-elements": "^0.12.5",
+        "@expo/metro-runtime": "~6.1.2",
         "@gluestack-ui/actionsheet": "^0.2.53",
         "@gluestack-ui/alert-dialog": "^0.1.38",
         "@gluestack-ui/button": "^1.0.14",
@@ -31,12 +32,11 @@
         "expo": "54.0.4",
         "expo-constants": "~18.0.8",
         "expo-dev-client": "~6.0.11",
-        "expo-file-system": "^19.0.12",
         "expo-font": "~14.0.7",
         "expo-haptics": "~15.0.6",
         "expo-linking": "~8.0.7",
-        "expo-router": "~6.0.2",
-        "expo-splash-screen": "~31.0.8",
+        "expo-router": "~6.0.3",
+        "expo-splash-screen": "~31.0.10",
         "expo-status-bar": "~3.0.7",
         "lottie-react-native": "~7.3.1",
         "lucide-react-native": "^0.539.0",
@@ -2495,6 +2495,29 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/@expo/metro-runtime": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-6.1.2.tgz",
+      "integrity": "sha512-nvM+Qv45QH7pmYvP8JB1G8JpScrWND3KrMA6ZKe62cwwNiX/BjHU28Ear0v/4bQWXlOY0mv6B8CDIm8JxXde9g==",
+      "license": "MIT",
+      "dependencies": {
+        "anser": "^1.4.9",
+        "pretty-format": "^29.7.0",
+        "stacktrace-parser": "^0.1.10",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-dom": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@expo/osascript": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.7.tgz",
@@ -2534,9 +2557,9 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "54.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.2.tgz",
-      "integrity": "sha512-JFWwwUTgU0+/79tG+vZnQRruM9agOJl3yiWOfyQVNdCdL13DF4a1nXvvCuNmuK6R7oEmyx8BhhAToY4Bmn0d+w==",
+      "version": "54.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.3.tgz",
+      "integrity": "sha512-okf6Umaz1VniKmm+pA37QHBzB9XlRHvO1Qh3VbUezy07LTkz87kXUW7uLMmrA319WLavWSVORTXeR0jBRihObA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config": "~12.0.9",
@@ -5019,9 +5042,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.2.tgz",
+      "integrity": "sha512-6L8PkB+m1SSb2kaGGFk3iXENxl8lrs7cyVl7AXH6pgdMfulDfM6yUrVdjtxdnGrLrGzzuav8fFnZMY+rcscqcA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -5035,9 +5058,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6150,9 +6173,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
+      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6408,6 +6431,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.2.tgz",
+      "integrity": "sha512-NvcIedLxrs9llVpX7wI+Jz4Hn9vJQkCPKrTaHIE0sW/Rj1iq6Fzby4NbyTZjQJNoypBXNaG7tEHkTgONZpwgxQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -6507,9 +6539,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.0.tgz",
+      "integrity": "sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6526,9 +6558,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001737",
-        "electron-to-chromium": "^1.5.211",
-        "node-releases": "^2.0.19",
+        "baseline-browser-mapping": "^2.8.2",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
         "update-browserslist-db": "^1.1.3"
       },
       "bin": {
@@ -7628,9 +7661,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.217",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.217.tgz",
-      "integrity": "sha512-Pludfu5iBxp9XzNl0qq2G87hdD17ZV7h5T4n6rQXDi3nCyloBV3jreE9+8GC6g4X/5yxqVgXEURpcLtM0WS4jA==",
+      "version": "1.5.218",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
+      "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8717,9 +8750,9 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.2.tgz",
-      "integrity": "sha512-yVNElc/hB5gsbA7pQrP4JPWvANK2r2uCqjocuKHI8lDC1bdaMbEEyYzyKaGIRD5Bx6RuEyy3D5UvGArOZZMi8Q==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.3.tgz",
+      "integrity": "sha512-TNBHE7qMutUB6GlXciNRZYH1H6bxXR6knzsEHQoBypSvCHdFYpq/EvUtc5BG+umHjTJaJq3WVzDFJ8Xl/WP0+w==",
       "license": "MIT",
       "dependencies": {
         "@expo/schema-utils": "^0.1.7",
@@ -8746,7 +8779,7 @@
         "vaul": "^1.1.2"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^6.1.1",
+        "@expo/metro-runtime": "^6.1.2",
         "@react-navigation/drawer": "^7.5.0",
         "@testing-library/react-native": ">= 12.0.0",
         "expo": "*",
@@ -8799,12 +8832,12 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "31.0.9",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.9.tgz",
-      "integrity": "sha512-pYLWFrEHn/c8e1a8oDzrlcyYI08oG4i37KA+VN5wwoC1DsQ0rm3kyAk0bmoydV1mBzNfXQFYbA1BGftXJl1f0w==",
+      "version": "31.0.10",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.10.tgz",
+      "integrity": "sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A==",
       "license": "MIT",
       "dependencies": {
-        "@expo/prebuild-config": "^54.0.1"
+        "@expo/prebuild-config": "^54.0.3"
       },
       "peerDependencies": {
         "expo": "*"
@@ -8830,16 +8863,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-file-system": {
-      "version": "19.0.13",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.13.tgz",
-      "integrity": "sha512-ACDxp9/HA30XxqLEX39dTNvjf/9R64woMoeySu02xoclGl98VsHTQhKk0GF4BxjD0KwA9jamS/scTaC9P0BWLA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {
@@ -11949,14 +11972,14 @@
       }
     },
     "node_modules/nativewind": {
-      "version": "4.1.23",
-      "resolved": "https://registry.npmjs.org/nativewind/-/nativewind-4.1.23.tgz",
-      "integrity": "sha512-oLX3suGI6ojQqWxdQezOSM5GmJ4KvMnMtmaSMN9Ggb5j7ysFt4nHxb1xs8RDjZR7BWc+bsetNJU8IQdQMHqRpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/nativewind/-/nativewind-4.2.0.tgz",
+      "integrity": "sha512-FjH4mu474tdEQRGfE5PwhPLmM3ldp5XLAEQN7yciOMF2ZEMHw6Qm3gmRwzRbhpOOefxAnjkZ5c9NY3ZWvKFx5w==",
       "license": "MIT",
       "dependencies": {
         "comment-json": "^4.2.5",
         "debug": "^4.3.7",
-        "react-native-css-interop": "0.1.22"
+        "react-native-css-interop": "0.2.0"
       },
       "engines": {
         "node": ">=16"
@@ -12003,9 +12026,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
-      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -13367,16 +13390,16 @@
       }
     },
     "node_modules/react-native-css-interop": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/react-native-css-interop/-/react-native-css-interop-0.1.22.tgz",
-      "integrity": "sha512-Mu01e+H9G+fxSWvwtgWlF5MJBJC4VszTCBXopIpeR171lbeBInHb8aHqoqRPxmJpi3xIHryzqKFOJYAdk7PBxg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-css-interop/-/react-native-css-interop-0.2.0.tgz",
+      "integrity": "sha512-16eCBhbUwgux5hk0Awm2A6GaMkiIBO+ynh+Yqfoy9a/huNJTfEMSCeg409mNiD4oYqC2CVaOjg5t6lbKPEPaUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/traverse": "^7.23.0",
         "@babel/types": "^7.23.0",
         "debug": "^4.3.7",
-        "lightningcss": "^1.27.0",
+        "lightningcss": "~1.27.0",
         "semver": "^7.6.3"
       },
       "engines": {
@@ -13395,6 +13418,246 @@
         "react-native-svg": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
+      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.27.0",
+        "lightningcss-darwin-x64": "1.27.0",
+        "lightningcss-freebsd-x64": "1.27.0",
+        "lightningcss-linux-arm-gnueabihf": "1.27.0",
+        "lightningcss-linux-arm64-gnu": "1.27.0",
+        "lightningcss-linux-arm64-musl": "1.27.0",
+        "lightningcss-linux-x64-gnu": "1.27.0",
+        "lightningcss-linux-x64-musl": "1.27.0",
+        "lightningcss-win32-arm64-msvc": "1.27.0",
+        "lightningcss-win32-x64-msvc": "1.27.0"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
+      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-darwin-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
+      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
+      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
+      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
+      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
+      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
+      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
+      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/react-native-css-interop/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -36,12 +36,11 @@
     "expo": "54.0.4",
     "expo-constants": "~18.0.8",
     "expo-dev-client": "~6.0.11",
-    "expo-file-system": "^19.0.12",
     "expo-font": "~14.0.7",
     "expo-haptics": "~15.0.6",
     "expo-linking": "~8.0.7",
-    "expo-router": "~6.0.2",
-    "expo-splash-screen": "~31.0.8",
+    "expo-router": "~6.0.3",
+    "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.7",
     "lottie-react-native": "~7.3.1",
     "lucide-react-native": "^0.539.0",
@@ -56,7 +55,8 @@
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1",
     "tailwindcss": "^3.4.17",
-    "toastify-react-native": "^7.2.3"
+    "toastify-react-native": "^7.2.3",
+    "@expo/metro-runtime": "~6.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -75,6 +75,11 @@
       "reactNativeDirectoryCheck": {
         "listUnknownPackages": false
       }
+    },
+    "install": {
+      "exclude": [
+        "expo-file-system"
+      ]
     }
   },
   "depcheck": {
@@ -87,6 +92,10 @@
     ]
   },
   "overrides": {
-    "expo-dev-menu": "7.0.10"
+    "expo-dev-menu": "7.0.10",
+    "expo-file-system": "19.0.12"
+  },
+  "resolutions": {
+    "expo-file-system": "19.0.12"
   }
 }


### PR DESCRIPTION
## 📝 Descrição

🔗 **Issue relacionada:** sem issue

Com a recente atualização do SDK do Expo para a versão 54, houve o bump de diversas dependências, sendo uma delas o **expo-file-system** para a versão `19.0.13`.

Essa nova versão do expo-file-system entretanto apresenta um defeito, inclusive apontado no GitHub do próprio Expo: [issue](https://github.com/expo/expo/issues/39622)

A correção temporária para esse problema é forçar um override da versão, para uma versão legado.

## ✅ Checklist

- [x] Revisei a doc [Pull Request](https://github.com/PointTils/Frontend/wiki/Pull-Requests) e abri meu PR de acordo
- [x] Meu código segue os padrões de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código, especialmente em áreas difíceis de entender
- [x] Minhas mudanças não geram novos warnings
- [x] Testei em dispositivo físico/emulador

## 📋 Informações Adicionais

Development build gerada com a correção para teste: [build](https://expo.dev/accounts/point-tils/projects/point-tils/builds/9b20a3b6-ba01-44f6-af17-8bf861f036a8)

---

> **Nota:** Certifique-se de que todos os checks da CI passaram antes de solicitar review.
