### PR TITLE
Corrige envio de valor minimo da faixa de precos do interprete

### DIFF
--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -121,6 +121,7 @@ export const buildEditPayload = (type: string, fields: any): UserRequest => {
           image_rights:
             fields.imageRight.value === Strings.common.options.authorize,
           max_value: Number(fields.maxPrice.value),
+          min_value: Number(fields.minPrice.value),
         },
       };
     default:


### PR DESCRIPTION
## 📝 Descrição

https://github.com/PointTils/Frontend/issues/81

Tela de edição do usuário intérprete não estava atualizando valor mínimo da faixa de valores pois faltava o mapeamento do min_value no corpo da requisição para a API Backend

## 📱 Screenshots/Videos

<img height="400" alt="image" src="https://github.com/user-attachments/assets/5bf5038d-7640-4cba-b6bb-2ec0cf849765" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/615f7b45-b527-4394-8840-6b7be27a58e3" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/5608ceab-dd8b-4c5c-af1f-73e84e206b91" />

## ✅ Checklist

- [x] Revisei a doc [Pull Request](https://github.com/PointTils/Frontend/wiki/Pull-Requests) e abri meu PR de acordo
- [X] Meu código segue os padrões de estilo do projeto
- [X] Realizei uma auto-revisão do meu código
- [ ] Comentei meu código, especialmente em áreas difíceis de entender
- [X] Minhas mudanças não geram novos warnings
- [X] Testei em dispositivo físico/emulador

## 📋 Informações Adicionais

Nenhum